### PR TITLE
Add support for renaming folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Simplest File Renamer
+# Simplest File (& Folder) Renamer
 
-Rename your files directly or with your favorite text editor, making use of all your 1337 keyboard shortcuts 😉
+Rename your files and folders directly or with your favorite text editor, making use of all your 1337 keyboard shortcuts 😉
 
 ![image](https://user-images.githubusercontent.com/17264277/69740803-0042a680-1108-11ea-9821-bc7c7f8e522d.png)
 

--- a/main.ts
+++ b/main.ts
@@ -138,11 +138,35 @@ ipc.on('choose-file', function (event) {
   });
 });
 
+ipc.on('open-folder-dialog', function (event) {
+  dialog.showOpenDialog(win, {
+    properties: ['openDirectory', 'multiSelections']
+  }).then(result => {
+    console.log(result);
+    const filePath: string[] = result.filePaths;
+    if (filePath.length) {
+      event.sender.send('file-chosen', filePath);
+    }
+  }).catch(err => {
+    console.log('choose-folder: this should not happen!');
+    console.log(err);
+  });
+});
+
 ipc.on('rename-these-files', function (event, filesToRename: RenameObject[]): void {
   console.log('renaming!!!');
   console.log(filesToRename);
 
-  const results: RenamedObject[] = filesToRename.map(element => renameThisFile(element));
+  const sortedFilesToRename: RenameObject[] = filesToRename
+  .slice()
+  .sort((a, b) => {
+    const depthA = path.resolve(a.path).split(path.sep).length;
+    const depthB = path.resolve(b.path).split(path.sep).length;
+
+    return depthB - depthA;
+  });
+
+  const results: RenamedObject[] = sortedFilesToRename.map(element => renameThisFile(element));
 
   console.log(results);
   angularApp.sender.send('renaming-report', results);
@@ -238,7 +262,7 @@ ipc.on('open-txt-file', function (event, files: string): void {
 let lastModified: number = 0;
 
 /**
- * Check if file has been edited
+ * Check if file/folder has been edited
  * if so, send its contents back to the app
  */
 ipc.on('app-back-in-focus', function (event): void {

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -61,7 +61,7 @@
 </div>
 
 <div class="instructions" *ngIf="sourceOfTruth.length === 0">
-  Drag & Drop files here
+  Drag & Drop files and/or folders here
 </div>
 
 <!-- =========================================================================================== -->
@@ -69,10 +69,21 @@
 
 <button
   *ngIf="mode === 'edit'"
-  class="button-left"
+  class="button-add button-add-files"
   (click)="addFile()"
   title="Add files"
 >
+  <app-icon [icon]="'icon-file'"></app-icon>
+  <app-icon [icon]="'icon-add'"></app-icon>
+</button>
+
+<button
+  *ngIf="mode === 'edit'"
+  class="button-add button-add-folders"
+  (click)="addFolder()"
+  title="Add folders"
+>
+  <app-icon [icon]="'icon-folder'"></app-icon>
   <app-icon [icon]="'icon-add'"></app-icon>
 </button>
 

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -68,6 +68,29 @@ button {
   }
 }
 
+.button-add {
+  width: 72px;
+  height: 40px;
+  border-radius: 10px;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+}
+
+.button-add-files {
+  left: 20px;
+}
+
+.button-add-folders {
+  left: 102px;
+}
+
+.button-add app-icon {
+  width: 15px;
+  height: 15px;
+}
+
 .button-left {
   left: 20px;
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -220,9 +220,9 @@ export class HomeComponent implements AfterViewInit, OnInit {
   }
 
   /**
-   * Add files to current list
-   * 1) don't add unless it's a file not on the list
-   * 2) append _input_ and _output_ with new filename
+   * Add files/folders to current list
+   * 1) don't add unless it's a file/folder not on the list
+   * 2) append _input_ and _output_ with new filename/foldername
    * 3) reload the diff view
    * @param files
    */
@@ -248,17 +248,21 @@ export class HomeComponent implements AfterViewInit, OnInit {
     files.forEach((file: string) => {
 
       const currentFile = path.parse(file);
+      const stats = this.electronService.fs.statSync(file);
+      const isDirectory = stats.isDirectory();
 
-      if (currentFile.ext) { // only add if extension exists (else it's a folder)
+      if (stats.isFile() || isDirectory) {
+
+        const filename = isDirectory ? currentFile.base : currentFile.name;
+        const extension = isDirectory ? '' : currentFile.ext;
 
         let fileAlreadyAdded: boolean = false;
 
-        // Validate the file hasn't been added yet
         this.sourceOfTruth.forEach((element) => {
           if (
-               element.filename  === currentFile.name
+               element.filename  === filename
             && element.path      === currentFile.dir
-            && element.extension === currentFile.ext
+            && element.extension === extension
           ) {
             fileAlreadyAdded = true;
           }
@@ -267,13 +271,13 @@ export class HomeComponent implements AfterViewInit, OnInit {
         if (!fileAlreadyAdded) {
 
           this.sourceOfTruth.push({
-            extension: currentFile.ext,
-            filename: currentFile.name,
+            extension: extension,
+            filename: filename,
             path: currentFile.dir,
           });
 
-          newInput.ops.push({ insert: currentFile.name + '\n' });
-          newOutput.ops.push({ insert: currentFile.name + '\n' });
+          newInput.ops.push({ insert: filename + '\n' });
+          newOutput.ops.push({ insert: filename + '\n' });
         }
       }
     });
@@ -366,9 +370,14 @@ export class HomeComponent implements AfterViewInit, OnInit {
   addFile() {
     this.electronService.ipcRenderer.send('choose-file');
   }
-
+   /**
+   * Open system dialog for adding new folder or folders
+   */
+  addFolder() {
+    this.electronService.ipcRenderer.send('open-folder-dialog');
+  }
   /**
-   * Open the filenames with system's default .txt editor
+   * Open the filenames/foldernames with system's default .txt editor
    */
   openTXT() {
     this.editingInTXT = true;

--- a/src/app/home/icons/icon.component.html
+++ b/src/app/home/icons/icon.component.html
@@ -4,5 +4,13 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlinx"
 >
-  <use [attr.xlink:href]="'#' + icon"></use>
+    <use [attr.href]="'#' + icon"></use>
+
+    <use
+
+        *ngIf="overlayIcon"
+
+        [attr.href]="'#' + overlayIcon">
+
+    </use>
 </svg>

--- a/src/app/home/icons/icon.component.ts
+++ b/src/app/home/icons/icon.component.ts
@@ -7,7 +7,8 @@ import { Component, Input } from '@angular/core';
 })
 export class IconComponent {
 
-  @Input() icon: string;
+  @Input() icon!: string;
+  @Input() overlayIcon?: string;
 
   constructor() { }
 

--- a/src/app/home/icons/svg-definitions.component.html
+++ b/src/app/home/icons/svg-definitions.component.html
@@ -19,6 +19,47 @@
       <rect x="4" y="6.75" width="7" height="1.5" />
     </symbol>
 
+    <symbol id="icon-file" viewBox="0 0 15 15">
+      <path
+        d="M3 2.25h5l3 3v7.5H3z"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="0.8"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M8 2.25v3h3"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="0.8"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M5 7.2h4M5 9h3"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="0.8"
+        stroke-linecap="round"
+      />
+    </symbol>
+
+    <symbol id="icon-folder" viewBox="0 0 15 15">
+      <path
+        d="M2 4.5h3l1-1h2.5c.8 0 1.5.7 1.5 1.5v5.5c0 .8-.7 1.5-1.5 1.5H2c-.8 0-1.5-.7-1.5-1.5V6c0-.8.7-1.5 1.5-1.5z"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="0.8"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M1.5 6h10"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="0.8"
+        stroke-linecap="round"
+      />
+    </symbol>
+    
     <symbol id="icon-checkmark" viewBox="0 0 15 15">
       <polygon
         points="11.48,5.55 10.42,4.49 6.52,8.39 4.57,6.44 3.52,7.5 6.53,10.51 7.58,9.45 7.58,9.45"

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 
   <head>
     <meta charset="utf-8">
-    <title>Simplest File Renamer</title>
+    <title>Simplest File (& Folder) Renamer</title>
     <base href="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
## Summary

This PR adds support for renaming folders in addition to files while keeping the existing workflow intact.

### Changes

- Added support for renaming folders
- Added separate **Add Files** and **Add Folders** buttons
- Added drag & drop support for folders
- Files and folders can now be renamed together
- Nested folders are renamed safely by processing deeper paths first
- Updated icons and UI text to reflect folder support

The existing file renaming workflow remains unchanged and is fully compatible.

<img width="1096" height="930" alt="Bildschirmfoto 2026-06-30 um 16 49 59" src="https://github.com/user-attachments/assets/933ea7c3-354e-4157-a9fc-352aab81fd5e" />
