### PR TITLE
cleanup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,17 +24,14 @@ fn rename(old: &str, new: &str) -> RustRenameResult {
 
         match fs::rename(old, &wip) {
             Ok(_) => {
-
                 match fs::rename(wip, new) {
                     Ok(_) => {
-
                         return RustRenameResult {
                             result: "renamed".to_string(),
                             msg: "".to_string(),
                         };
                     },
                     Err(err) => {
-
                         return RustRenameResult {
                             result: "error".to_string(),
                             msg: err.to_string(),
@@ -43,7 +40,6 @@ fn rename(old: &str, new: &str) -> RustRenameResult {
                 };
             },
             Err(err) => {
-
                 return RustRenameResult {
                     result: "error".to_string(),
                     msg: err.to_string(),
@@ -52,36 +48,35 @@ fn rename(old: &str, new: &str) -> RustRenameResult {
         };
     }
 
-    let file_exists_test = match Path::new(new).try_exists() {
-        Ok(true) => "1",  // filename already exists -- CAN NOT rename
-        Ok(false) => "2", // good news -- you can try to rename
-        Err(e) => &e.to_string(),
-    };
-
-    let mut outcome = "renamed";
-    let mut err_msg: String = "".to_string();
-
-    if file_exists_test == "1" {
-        outcome = "error";
-        err_msg = "file name already exists".to_string();
-    } else if file_exists_test == "2" {
-        let rename_operation_done: String = match fs::rename(old, new) {
-            Ok(_) => "renamed".to_string(),
-            Err(err) => err.to_string(),
-        };
-
-        if rename_operation_done != "renamed" {
-            outcome = "error";
-            err_msg = rename_operation_done;
-        }
-    } else {
-        outcome = "error";
-        err_msg = file_exists_test.to_string();
-    }
-
-    return RustRenameResult {
-        result: outcome.to_string(),
-        msg: err_msg.to_string(),
+    match Path::new(new).try_exists() {
+        Ok(true) => { // filename already exists -- CAN NOT rename
+            return RustRenameResult {
+                result:  "error".to_string(),
+                msg: "file name already exists".to_string(),
+            };
+        },
+        Ok(false) => { // good news -- you can try to rename
+            match fs::rename(old, new) {
+                Ok(_) => {
+                    return RustRenameResult {
+                        result: "renamed".to_string(),
+                        msg: "".to_string(),
+                    };
+                },
+                Err(err) => {
+                    return RustRenameResult {
+                        result: "error".to_string(),
+                        msg: err.to_string(),
+                    };
+                }
+            };
+        },
+        Err(err) => { // some error, return to user
+            return RustRenameResult {
+                result: "error".to_string(),
+                msg: err.to_string(),
+            };
+        },
     };
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,7 @@ pub struct RustRenameResult {
     msg: String,
 }
 
-fn rename_result(success: bool, error: String) -> RustRenameResult {
+fn result(success: bool, error: String) -> RustRenameResult {
     if success {
         return RustRenameResult {
             result: "renamed".to_string(),
@@ -39,23 +39,23 @@ fn rename(old: &str, new: &str) -> RustRenameResult {
         match fs::rename(old, &wip) {
             Ok(_) => {
                 match fs::rename(wip, new) {
-                    Ok(_) =>           return rename_result(true, "".to_string()),
-                    Err(err) => return rename_result(false, err.to_string())
+                    Ok(_) =>           return result(true, "".to_string()),
+                    Err(err) => return result(false, err.to_string())
                 };
             },
-            Err(err) => {       return rename_result(false, err.to_string()) }
+            Err(err) => {       return result(false, err.to_string()) }
         };
     }
 
     match Path::new(new).try_exists() {
-        Ok(true) =>                    return rename_result(false, "file name already exists".to_string()),
+        Ok(true) =>                    return result(false, "file name already exists".to_string()),
         Ok(false) => {
             match fs::rename(old, new) {
-                Ok(_) =>               return rename_result(true,"".to_string()),
-                Err(err) =>     return rename_result(false, err.to_string())
+                Ok(_) =>               return result(true, "".to_string()),
+                Err(err) =>     return result(false, err.to_string())
             };
         },
-        Err(err) => {           return rename_result(false, err.to_string()) }
+        Err(err) => {           return result(false, err.to_string()) }
     };
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,20 @@ pub struct RustRenameResult {
     msg: String,
 }
 
+fn rename_result(success: bool, error: String) -> RustRenameResult {
+    if success {
+        return RustRenameResult {
+            result: "renamed".to_string(),
+            msg: "".to_string(),
+        };
+    } else {
+        return RustRenameResult {
+            result: "error".to_string(),
+            msg: error.to_string(),
+        };
+    }
+}
+
 #[tauri::command]
 fn rename(old: &str, new: &str) -> RustRenameResult {
 
@@ -25,58 +39,23 @@ fn rename(old: &str, new: &str) -> RustRenameResult {
         match fs::rename(old, &wip) {
             Ok(_) => {
                 match fs::rename(wip, new) {
-                    Ok(_) => {
-                        return RustRenameResult {
-                            result: "renamed".to_string(),
-                            msg: "".to_string(),
-                        };
-                    },
-                    Err(err) => {
-                        return RustRenameResult {
-                            result: "error".to_string(),
-                            msg: err.to_string(),
-                        };
-                    }
+                    Ok(_) =>           return rename_result(true, "".to_string()),
+                    Err(err) => return rename_result(false, err.to_string())
                 };
             },
-            Err(err) => {
-                return RustRenameResult {
-                    result: "error".to_string(),
-                    msg: err.to_string(),
-                };
-            }
+            Err(err) => {       return rename_result(false, err.to_string()) }
         };
     }
 
     match Path::new(new).try_exists() {
-        Ok(true) => { // filename already exists -- CAN NOT rename
-            return RustRenameResult {
-                result:  "error".to_string(),
-                msg: "file name already exists".to_string(),
-            };
-        },
-        Ok(false) => { // good news -- you can try to rename
+        Ok(true) =>                    return rename_result(false, "file name already exists".to_string()),
+        Ok(false) => {
             match fs::rename(old, new) {
-                Ok(_) => {
-                    return RustRenameResult {
-                        result: "renamed".to_string(),
-                        msg: "".to_string(),
-                    };
-                },
-                Err(err) => {
-                    return RustRenameResult {
-                        result: "error".to_string(),
-                        msg: err.to_string(),
-                    };
-                }
+                Ok(_) =>               return rename_result(true,"".to_string()),
+                Err(err) =>     return rename_result(false, err.to_string())
             };
         },
-        Err(err) => { // some error, return to user
-            return RustRenameResult {
-                result: "error".to_string(),
-                msg: err.to_string(),
-            };
-        },
+        Err(err) => {           return rename_result(false, err.to_string()) }
     };
 }
 

--- a/src/app/comparison/comparison.component.scss
+++ b/src/app/comparison/comparison.component.scss
@@ -24,12 +24,13 @@
     border-radius: 5px;
     border: 1px solid gray;
     display: none;
-    padding: 5px 10px;
+    padding: 8px 12px;
     transform: translate(-10px, -3px);
     position: absolute;
     text-align: center;
     white-space: nowrap;
     z-index: 21;
+    box-shadow: rgba(0, 0, 0, 0.1) 2px 4px 6px -1px, rgba(0, 0, 0, 0.06) 0px 2px 4px -1px;
   }
 
   &:hover {

--- a/src/app/file.service.ts
+++ b/src/app/file.service.ts
@@ -93,6 +93,12 @@ export class FileService {
       return renamedObject;
     }
 
+    if (file.newFilename.includes('\\')) {
+      renamedObject.result = 'error';
+      renamedObject.error = 'can not have "\\`" in filename';
+      return renamedObject;
+    }
+
     const original: string = await join(file.path, file.filename + file.extension);
     const newName: string = await join(file.path, file.newFilename + file.extension);
 

--- a/src/app/file.service.ts
+++ b/src/app/file.service.ts
@@ -37,10 +37,10 @@ export class FileService {
   }
 
   async renameTheseFiles(filesToRename: RenameObject[]): Promise<RenamedObject[]> {
-    console.log('renaming!!!');
-    console.log(filesToRename);
 
-    const sortedFilesToRename: RenameObject[] = filesToRename
+    const itemsWithIndex = filesToRename.map((item, index) => ({ ...item, idx: index }));
+
+    const sortedFilesToRename: RenameObject[] = itemsWithIndex
     .slice()
     .sort((a, b) => {
       const depthA = (a.path).split(this.sep).length;
@@ -56,8 +56,9 @@ export class FileService {
       results.push(result);
     }
 
-    console.log(results);
-    return results;
+    const unscrambled = results.sort((a, b) => a.idx - b.idx);
+
+    return unscrambled;
   }
 
   /**
@@ -68,6 +69,7 @@ export class FileService {
   async renameThisFile(file: RenameObject): Promise<RenamedObject> {
 
     const renamedObject: RenamedObject = {
+      idx: file.idx,
       path: file.path,
       filename: file.filename,
       extension: file.extension,
@@ -101,10 +103,6 @@ export class FileService {
 
     const original: string = await join(file.path, file.filename + file.extension);
     const newName: string = await join(file.path, file.newFilename + file.extension);
-
-    console.log('renaming file:');
-    console.log(original);
-    console.log(newName);
 
     let response: RustRenameResult = { msg: '', result: '' };
 

--- a/src/app/interfaces.ts
+++ b/src/app/interfaces.ts
@@ -10,6 +10,7 @@ export interface RenameObject extends SourceOfTruth {
   newFilename: string;
   result?: RenameResult; // added just to avoid TS2339 in comparison.component.html
   error?: string;        // added just to avoid TS2339 in comparison.component.html
+  idx?: number; // for unscrambling the sorted array in `renameTheseFiles`
 }
 
 export type RenameResult = 'renamed' | 'unchanged' | 'error' | undefined;


### PR DESCRIPTION
- catch `\` before renaming and let user know not to do that :trollface: 
- more-readable _rust_ code 😅 
- keep the results of renaming the same as original (previously scrambled when sorting by path depth for folder renaming)